### PR TITLE
Added plot for small batch 4gke dyn batch on vs off, updated plot scripts 2-5c to generate full event time plots as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,19 @@ the second file "results_rscaletest-gke4.txt" has two additional columns:
 Contents of files:
 * results_rscaletest-gke1.txt: GKE-1gpu server results with Dynamic Batching turned On
 * results_rscaletest-gke4.txt: GKE-4gpu server results with Dynamic Batching turned On
+* results_rscaletest-gke4_bigbat.txt: GKE-4gpu server results with Dynamic Batching turned On, and max batch size per wire plane set to 16384 (avg~=1720)
 * results_rscaletest-gke4_nodybat.txt: GKE-4gpu server results with Dynamic Batching turned Off, and max batch size per wire plane set to 256 (avg~=235)
 * results_rscaletest-gke4_nodybat_bigbat.txt: GKE-4gpu server results with Dynamic Batching turned Off, and max batch size per wire plane set to 16384 (avg~=1720)
 
 Plots:
 * plot1: dynamic batching On: [gke-1gpu] vs [gke-4gpu]
-* plot1b: full event time, dyn batch on vs off
+* plot1b: full event time, dyn batch on vs off (with model for dyn batch off)
+* plot1c: full event time, dyn batch on vs off (with models for dyn batch on vs off)
 * plot2: gke-4gpu: [dynamic batching On] vs [dynamic batching Off]
 * plot3: gke-4gpu, dynamic batching Off: [small batch size] vs [big batch size]
 * plot4: gke-4gpu: [dynamic batch On, small batch size] vs [dynamic batching Off, big batch size]
 * plot5a: gke-4gpu: [dynamic batch On, big batch size] vs [dynamic batching Off, big batch size]
-* plot5a: gke-4gpu: [dynamic batch On, big batch size] vs [dynamic batching On, small batch size]
+* plot5b: gke-4gpu: [dynamic batch On, big batch size] vs [dynamic batching On, small batch size]
+* plot5c: gke-4gpu: [dynamic batch On, small batch size] vs [dynamic batching Off, small batch size]
 
+Plot scrips 2-5c generates a plot file for [EmTrackMichelId time vs number of simultaneous jobs] and [full event time vs number of simultaneous jobs] for each comparison

--- a/plot-2.py
+++ b/plot-2.py
@@ -6,6 +6,7 @@ import numpy as np
 d1=np.loadtxt("data/results_rscaletest-gke4_nodybat.txt")
 d4=np.loadtxt("data/results_rscaletest-gke4.txt")
 
+# EmTrackMichelID Time
 fig=plt.figure()
 ax=fig.add_subplot(111)
 
@@ -20,7 +21,23 @@ ax.set(title="EmTrkMichelId module proc time vs # jobs (GKE-4gpu)", xlabel="numb
 #yr=[219.4,219.4]
 #ax.plot(xr, yr, color='orange',label = "without tRTis",linestyle='solid',linewidth=2)
 
-plt.legend()
-plt.tight_layout()
-plt.savefig("plot-2.png")
-plt.show()
+ax.legend()
+fig.tight_layout()
+fig.savefig("plot-2_EMTrackMichelID.png")
+fig.show()
+
+# Full Event Time
+fig2=plt.figure()
+ax2=fig2.add_subplot(111)
+
+ax2.set_xlim(0,310)
+ax2.set_ylim(0,250)
+ax2.grid(True)
+ax2.errorbar(d1[:,0], d1[:,1], yerr=d1[:,2], fmt='r^--', linewidth=0.8,markersize=7, markeredgecolor='red', fillstyle='none', capsize=3, label = "w/ tRTis on GKE-4gpu, dynamic batching Off")
+ax2.errorbar(d4[:,0], d4[:,1], yerr=d4[:,2], fmt='bv--', linewidth=0.8,markersize=7, markeredgecolor='blue', fillstyle='none', capsize=3, label = "w/ tRTis on GKE-4gpu, dynamic batching On")
+ax2.set(title="Full Event proc time vs # jobs (GKE-4gpu)", xlabel="number of simultaneous jobs", ylabel="processing time [seconds]")
+
+ax2.legend()
+fig2.tight_layout()
+fig2.savefig("plot-2_FullEvent.png")
+fig2.show()

--- a/plot-3.py
+++ b/plot-3.py
@@ -6,6 +6,7 @@ import numpy as np
 d4a=np.loadtxt("data/results_rscaletest-gke4_nodybat.txt")
 d4b=np.loadtxt("data/results_rscaletest-gke4_nodybat_bigbat.txt")
 
+# EMTrackMichelID Time
 fig=plt.figure()
 ax=fig.add_subplot(111)
 
@@ -20,7 +21,23 @@ ax.set(title="EmTrkMichelId module proc time vs # jobs (GKE-4gpu, no dynamic bat
 #yr=[219.4,219.4]
 #ax.plot(xr, yr, color='orange',label = "without tRTis",linestyle='solid',linewidth=2)
 
-plt.legend()
-plt.tight_layout()
-plt.savefig("plot-3.png")
-plt.show()
+ax.legend()
+fig.tight_layout()
+fig.savefig("plot-3_EMTrackMichelID.png")
+fig.show()
+
+# Full Event Time
+fig2=plt.figure()
+ax2=fig2.add_subplot(111)
+
+ax2.set_xlim(0,310)
+ax2.set_ylim(0,250)
+ax2.grid(True)
+ax2.errorbar(d4a[:,0], d4a[:,1], yerr=d4a[:,2], fmt='r^--', linewidth=0.8,markersize=7, markeredgecolor='red', fillstyle='none', capsize=3, label = "w/ tRTis on GKE-4gpu, avg batch size = 235")
+ax2.errorbar(d4b[:,0], d4b[:,1], yerr=d4b[:,2], fmt='bD--', linewidth=0.8,markersize=5.5, markeredgecolor='blue', fillstyle='none', capsize=3, label = "w/ tRTis on GKE-4gpu, avg batch size = 1720")
+ax2.set(title="Full Event proc time vs # jobs (GKE-4gpu, no dynamic batching)", xlabel="number of simultaneous jobs", ylabel="processing time [seconds]")
+
+ax2.legend()
+fig2.tight_layout()
+fig2.savefig("plot-3_FullEvent.png")
+fig2.show()

--- a/plot-4.py
+++ b/plot-4.py
@@ -6,13 +6,14 @@ import numpy as np
 d4a=np.loadtxt("data/results_rscaletest-gke4.txt")
 d4b=np.loadtxt("data/results_rscaletest-gke4_nodybat_bigbat.txt")
 
+# EMTrackMichelID Time
 fig=plt.figure()
 ax=fig.add_subplot(111)
 
 ax.set_xlim(0,310)
 ax.set_ylim(0,60)
 ax.grid(True)
-ax.errorbar(d4a[:,0], d4a[:,3], yerr=d4a[:,4], fmt='rv--', linewidth=0.8,markersize=7, markeredgecolor='r', fillstyle='none', capsize=3, label = "w/ tRTis on GKE-4gpu, dyn bat On, avg bat sz = 235, ")
+ax.errorbar(d4a[:,0], d4a[:,3], yerr=d4a[:,4], fmt='rv--', linewidth=0.8,markersize=7, markeredgecolor='r', fillstyle='none', capsize=3, label = "w/ tRTis on GKE-4gpu, dyn bat On, avg bat sz = 235")
 ax.errorbar(d4b[:,0], d4b[:,3], yerr=d4b[:,4], fmt='bD--', linewidth=0.8,markersize=5.5, markeredgecolor='b', fillstyle='none', capsize=3, label = "w/ tRTis on GKE-4gpu, dyn bat Off, avg bat sz = 1720")
 ax.set(title="EmTrkMichelId module proc time vs # jobs (GKE-4gpu)", xlabel="number of simultaneous jobs", ylabel="processing time [seconds]")
 
@@ -20,7 +21,24 @@ ax.set(title="EmTrkMichelId module proc time vs # jobs (GKE-4gpu)", xlabel="numb
 #yr=[219.4,219.4]
 #ax.plot(xr, yr, color='orange',label = "without tRTis",linestyle='solid',linewidth=2)
 
-plt.legend()
-plt.tight_layout()
-plt.savefig("plot-4.png")
-plt.show()
+ax.legend()
+fig.tight_layout()
+fig.savefig("plot-4_EMTrackMichelID.png")
+fig.show()
+
+# Full Event Time
+fig2=plt.figure()
+ax2=fig2.add_subplot(111)
+
+ax2.set_xlim(0,310)
+ax2.set_ylim(0,250)
+ax2.grid(True)
+ax2.errorbar(d4a[:,0], d4a[:,1], yerr=d4a[:,2], fmt='rv--', linewidth=0.8,markersize=7, markeredgecolor='r', fillstyle='none', capsize=3, label = "w/ tRTis on GKE-4gpu, dyn bat On, avg bat sz = 235")
+ax2.errorbar(d4b[:,0], d4b[:,1], yerr=d4b[:,2], fmt='bD--', linewidth=0.8,markersize=5.5, markeredgecolor='b', fillstyle='none', capsize=3, label = "w/ tRTis on GKE-4gpu, dyn bat Off, avg bat sz = 1720")
+ax2.set(title="Full Event proc time vs # jobs (GKE-4gpu)", xlabel="number of simultaneous jobs", ylabel="processing time [seconds]")
+
+ax2.legend()
+fig2.tight_layout()
+fig2.savefig("plot-4_FullEvent.png")
+fig2.show()
+

--- a/plot-5a.py
+++ b/plot-5a.py
@@ -6,6 +6,7 @@ import numpy as np
 d4a=np.loadtxt("data/results_rscaletest-gke4_bigbat.txt")
 d4b=np.loadtxt("data/results_rscaletest-gke4_nodybat_bigbat.txt")
 
+# EmTrackMichelIS Time
 fig=plt.figure()
 ax=fig.add_subplot(111)
 
@@ -20,7 +21,23 @@ ax.set(title="EmTrkMichelId module proc time vs # jobs (GKE-4gpu)", xlabel="numb
 #yr=[219.4,219.4]
 #ax.plot(xr, yr, color='orange',label = "without tRTis",linestyle='solid',linewidth=2)
 
-plt.legend()
-plt.tight_layout()
-plt.savefig("plot-5a.png")
-plt.show()
+ax.legend()
+fig.tight_layout()
+fig.savefig("plot-5a_EmTrackMichelID.png")
+fig.show()
+
+# Full Event Time
+fig2=plt.figure()
+ax2=fig2.add_subplot(111)
+
+ax2.set_xlim(0,410)
+ax2.set_ylim(0,250)
+ax2.grid(True)
+ax2.errorbar(d4b[:,0], d4b[:,1], yerr=d4b[:,2], fmt='bD--', linewidth=0.8,markersize=5.5, markeredgecolor='b', fillstyle='none', capsize=3, label = "w/ tRTis on GKE-4gpu, dyn bat Off, avg bat sz = 1720")
+ax2.errorbar(d4a[:,0], d4a[:,1], yerr=d4a[:,2], fmt='rv--', linewidth=0.8,markersize=7, markeredgecolor='r', fillstyle='none', capsize=3, label = "w/ tRTis on GKE-4gpu, dyn bat On, avg bat sz = 1720")
+ax2.set(title="Full Event proc time vs # jobs (GKE-4gpu)", xlabel="number of simultaneous jobs", ylabel="processing time [seconds]")
+
+ax2.legend()
+fig2.tight_layout()
+fig2.savefig("plot-5a_FullEvent.png")
+fig2.show()

--- a/plot-5b.py
+++ b/plot-5b.py
@@ -6,6 +6,7 @@ import numpy as np
 d4a=np.loadtxt("data/results_rscaletest-gke4_bigbat.txt")
 d4b=np.loadtxt("data/results_rscaletest-gke4.txt")
 
+# EmTrackMichelID Time
 fig=plt.figure()
 ax=fig.add_subplot(111)
 
@@ -20,7 +21,23 @@ ax.set(title="EmTrkMichelId module proc time vs # jobs (GKE-4gpu)", xlabel="numb
 #yr=[219.4,219.4]
 #ax.plot(xr, yr, color='orange',label = "without tRTis",linestyle='solid',linewidth=2)
 
-plt.legend()
-plt.tight_layout()
-plt.savefig("plot-5b.png")
-plt.show()
+ax.legend()
+fig.tight_layout()
+fig.savefig("plot-5b_EmTrackMichelID.png")
+fig.show()
+
+# Full Event Time
+fig2=plt.figure()
+ax2=fig2.add_subplot(111)
+
+ax2.set_xlim(0,410)
+ax2.set_ylim(0,250)
+ax2.grid(True)
+ax2.errorbar(d4b[:,0], d4b[:,1], yerr=d4b[:,2], fmt='bD--', linewidth=0.8,markersize=5.5, markeredgecolor='b', fillstyle='none', capsize=3, label = "w/ tRTis on GKE-4gpu, dyn bat On, avg bat sz = 235")
+ax2.errorbar(d4a[:,0], d4a[:,1], yerr=d4a[:,2], fmt='rv--', linewidth=0.8,markersize=7, markeredgecolor='r', fillstyle='none', capsize=3, label = "w/ tRTis on GKE-4gpu, dyn bat On, avg bat sz = 1720")
+ax2.set(title="Full Event module proc time vs # jobs (GKE-4gpu)", xlabel="number of simultaneous jobs", ylabel="processing time [seconds]")
+
+ax2.legend()
+fig2.tight_layout()
+fig2.savefig("plot-5b_FullEvent.png")
+fig2.show()

--- a/plot-5c.py
+++ b/plot-5c.py
@@ -1,0 +1,43 @@
+import matplotlib as mpl
+mpl.use('agg')
+import matplotlib.pyplot as plt
+import numpy as np
+
+d4a=np.loadtxt("data/results_rscaletest-gke4_nodybat.txt")
+d4b=np.loadtxt("data/results_rscaletest-gke4.txt")
+
+# EmTrackMichelId Time
+fig=plt.figure()
+ax=fig.add_subplot(111)
+
+ax.set_xlim(0,500)
+ax.set_ylim(0,225)
+ax.grid(True)
+ax.errorbar(d4b[:,0], d4b[:,3], yerr=d4b[:,4], fmt='rv--', linewidth=0.8,markersize=5.5, markeredgecolor='r', fillstyle='none', capsize=3, label = "w/ tRTis on GKE-4gpu, dyn bat On, avg bat sz = 235")
+ax.errorbar(d4a[:,0], d4a[:,3], yerr=d4a[:,4], fmt='bD--', linewidth=0.8,markersize=7, markeredgecolor='b', fillstyle='none', capsize=3, label = "w/ tRTis on GKE-4gpu, dyn bat Off, avg bat sz = 235")
+ax.set(title="EmTrkMichelId module proc time vs # jobs (GKE-4gpu)", xlabel="number of simultaneous jobs", ylabel="processing time [seconds]")
+
+#xr=[0.,310.]
+#yr=[219.4,219.4]
+#ax.plot(xr, yr, color='orange',label = "without tRTis",linestyle='solid',linewidth=2)
+
+ax.legend()
+fig.tight_layout()
+fig.savefig("plot-5c_EmTrackMichelId.png")
+fig.show()
+
+# Full Event Time
+fig2=plt.figure()
+ax2=fig2.add_subplot(111)
+
+ax2.set_xlim(0,500)
+ax2.set_ylim(0,350)
+ax2.grid(True)
+ax2.errorbar(d4b[:,0], d4b[:,1], yerr=d4b[:,2], fmt='rv--', linewidth=0.8,markersize=5.5, markeredgecolor='r', fillstyle='none', capsize=3, label = "w/ tRTis on GKE-4gpu, dyn bat On, avg bat sz = 235")
+ax2.errorbar(d4a[:,0], d4a[:,1], yerr=d4a[:,2], fmt='bD--', linewidth=0.8,markersize=7, markeredgecolor='b', fillstyle='none', capsize=3, label = "w/ tRTis on GKE-4gpu, dyn bat Off, avg bat sz = 235")
+ax2.set(title="Full Event proc time vs # jobs (GKE-4gpu)", xlabel="number of simultaneous jobs", ylabel="processing time [seconds]")
+
+ax2.legend()
+fig2.tight_layout()
+fig2.savefig("plot-5c_FullEvent.png")
+fig2.show()


### PR DESCRIPTION
At the request of Nhan, added a plot to compare dynamic batching on vs off for gke4 with a small batch size, also updated plot scripts 2-5c to generate plots for full event time along with EmTrackMichelID, adding the name of each onto the filename.  Also updated readme to reflect these changes and a few other fixes.